### PR TITLE
recurring-incidents.md: Replace "white cis-gendered" with "white cishet"

### DIFF
--- a/recurring-incidents.md
+++ b/recurring-incidents.md
@@ -45,7 +45,7 @@ So, here are some recurring issues, in no particular order:
 *What can we do?* Talk to the offender and give them a warning.
 *When?* Within 2 hours.
 
-- Denying white cis-gendered male privilege/Denying the existence of systemic inequality:
+- Denying white cishet male privilege/Denying the existence of systemic inequality:
 *What can we do?* Talk to the offender and give them a warning.
 *When?* Within 2 hours.
 


### PR DESCRIPTION
When talking about privilege, it's important to note that
gay men (esp. openly so) still face persecution and even
considerable danger in many places in the world, hence
the proposal to alter the wording to make the distinction.

Signed-off-by: Dog Mathematics <dogmathematics@gmail.com>